### PR TITLE
fix(proxy): auto-detect socket.io backend host from web/socketio instance

### DIFF
--- a/main.js
+++ b/main.js
@@ -294,6 +294,37 @@ function proxyWebSocket(req, socket, targetWsUrl, log) {
   proxyReq.end();
 }
 
+// ── Socket.io backend auto-detection ────────────────────────────────────────
+
+const SOCKET_BACKEND_WILDCARDS = new Set(['0.0.0.0', '::', '::0', '']);
+
+function pickSocketBackend(objectsMap, socketPort) {
+  const fallback = { host: '127.0.0.1', secure: false, source: null, found: false, conflicts: [] };
+  if (!Number.isInteger(socketPort) || socketPort <= 0) return fallback;
+  const candidates = [];
+  for (const [id, obj] of Object.entries(objectsMap || {})) {
+    const name = obj?.common?.name;
+    if (name !== 'web' && name !== 'socketio') continue;
+    if (!obj.common.enabled) continue;
+    const native = obj.native || {};
+    if (Number(native.port) !== Number(socketPort)) continue;
+    candidates.push({ id, native });
+  }
+  if (!candidates.length) return fallback;
+  candidates.sort((a, b) => a.id.localeCompare(b.id));
+  const pick = candidates[0];
+  const bind = String(pick.native.bind || '').trim();
+  const host = SOCKET_BACKEND_WILDCARDS.has(bind) ? '127.0.0.1' : bind;
+  const secure = !!pick.native.secure;
+  return {
+    host,
+    secure,
+    source: pick.id,
+    found: true,
+    conflicts: candidates.slice(1).map(c => c.id),
+  };
+}
+
 // ── Static file serving ──────────────────────────────────────────────────────
 
 const MIME_TYPES = {
@@ -492,10 +523,32 @@ class Aura extends utils.Adapter {
     }
   }
 
+  async resolveSocketBackend(socketPort) {
+    let objs;
+    try {
+      objs = await this.getForeignObjectsAsync('system.adapter.*', 'instance');
+    } catch (e) {
+      this.log.warn(`aura: socket backend auto-detect failed (${e.message}) — falling back to 127.0.0.1`);
+      return { host: '127.0.0.1', secure: false, source: null, found: false, conflicts: [] };
+    }
+    return pickSocketBackend(objs, socketPort);
+  }
+
   async startHttpServer() {
     const port       = this.config.port       || 8095;
     const socketPort = this.config.socketPort || 8082;
     const useHttps   = !!this.config.secure;
+
+    const backend = await this.resolveSocketBackend(socketPort);
+    const socketHost   = backend.host;
+    const socketSecure = backend.found ? backend.secure : !!this.config.socketSecure;
+    if (backend.found) {
+      const proto = socketSecure ? 'https' : 'http';
+      const extra = backend.conflicts.length ? ` (other matches ignored: ${backend.conflicts.join(', ')})` : '';
+      this.log.info(`aura: socket.io backend ${proto}://${socketHost}:${socketPort} (via ${backend.source})${extra}`);
+    } else {
+      this.log.warn(`aura: no enabled web/socketio instance found with port ${socketPort} — proxying to ${socketHost}:${socketPort}`);
+    }
 
     // ── File-system helpers ──────────────────────────────────────────────────
     const fsRootsConfig = Array.isArray(this.config.fsRoots)
@@ -654,14 +707,13 @@ class Aura extends utils.Adapter {
 
       const webAdapterPrefixes = ['/socket.io', '/echarts', '/lib'];
       if (webAdapterPrefixes.some(p => pathname === p || pathname.startsWith(p + '/'))) {
-        const socketSecure = !!this.config.socketSecure;
         const socketLib    = socketSecure ? https : http;
         const proxyReq = socketLib.request({
-          hostname: 'localhost',
+          hostname: socketHost,
           port: socketPort,
           path: req.url,
           method: req.method,
-          headers: { ...req.headers, host: `localhost:${socketPort}` },
+          headers: { ...req.headers, host: `${socketHost}:${socketPort}` },
           timeout: 30000,
           rejectUnauthorized: false,
         }, (proxyRes) => {
@@ -729,8 +781,8 @@ class Aura extends utils.Adapter {
       let parsedUrl;
       try { parsedUrl = new URL(req.url, 'http://localhost'); } catch { return; }
       if (parsedUrl.pathname.startsWith('/socket.io/')) {
-        const wsScheme = this.config.socketSecure ? 'wss' : 'ws';
-        proxyWebSocket(req, socket, `${wsScheme}://localhost:${socketPort}${req.url}`, this.log);
+        const wsScheme = socketSecure ? 'wss' : 'ws';
+        proxyWebSocket(req, socket, `${wsScheme}://${socketHost}:${socketPort}${req.url}`, this.log);
         return;
       }
       if (parsedUrl.pathname !== '/proxyws') return;


### PR DESCRIPTION
## Problem

Aura proxies all `/socket.io/*` requests (HTTP and WebSocket) from its own HTTP port to the configured `socketPort` (typically the `web` instance on 8082). The proxy target host is hardcoded to `localhost`:

- `main.js` L661 (HTTP proxy) — `hostname: 'localhost'`
- `main.js` L733 (WebSocket upgrade) — `ws://localhost:${socketPort}${req.url}`

When `web.0` (or `socketio.0`) is bound to a specific IP rather than `0.0.0.0`, the listening socket is not reachable via loopback. The proxy then fails with `ECONNREFUSED 127.0.0.1:8082` and aura returns `502 Bad Gateway` for `/socket.io/*`. Browsers connecting directly to `web.0`'s IP (VIS-2, Admin) keep working — only aura's internal proxy is affected.

### Reproducer

1. Set `system.adapter.web.0` → `bind` to a specific IP (e.g. `10.47.88.2`)
2. Start aura
3. `curl http://aura-host:8083/socket.io/?EIO=4&transport=polling` → `502 Bad Gateway` from aura; the WS-upgrade path fails the same way

## Fix

Detect the backend host (and `secure` flag) at adapter startup by looking up `system.adapter.web.*` / `system.adapter.socketio.*`, matching the configured `socketPort` against the instance's `native.port`:

- Wildcard binds (`0.0.0.0`, `::`, `::0`, empty) → fall back to `127.0.0.1`
- Specific IP bind → use that IP
- No matching instance → fall back to `127.0.0.1` (previous behaviour) + warn

The new `pickSocketBackend(objectsMap, socketPort)` helper is pure (easy to unit-test); `Adapter.resolveSocketBackend(socketPort)` wraps it with `getForeignObjectsAsync`. Both `socketHost` and `socketSecure` flow through the HTTP-proxy block and the WebSocket-upgrade handler.

Startup now logs the detected backend:

\`\`\`
aura: socket.io backend http://10.47.88.2:8082 (via system.adapter.web.0)
\`\`\`

## Backward compatibility

- Setups with `web` bound to `0.0.0.0` / wildcard are unchanged (auto-detect resolves to `127.0.0.1`)
- The existing `socketSecure` adapter setting is still honoured when auto-detection finds no instance; otherwise the detected value wins (single source of truth)
- No config-schema change, no new UI fields

## Test plan

- [x] Reproduced the 502 on a server with `web.0` bound to `10.47.88.2`
- [x] After patch: `aura: socket.io backend http://10.47.88.2:8082 (via system.adapter.web.0)` in startup log
- [x] `curl /socket.io/...&transport=polling` proxies through to `web.0` (no more 502 from aura)
- [x] WebSocket upgrade returns `HTTP/1.1 101 Switching Protocols`
- [x] Frontend `#/admin` loads end-to-end in the browser

> Note for testers: aura's `socket.io-client@2.x` requires a classic socket.io server on `web`. If `web.0` has *Use pure web sockets (iobroker.ws)* enabled, the engine.io handshake fails with `No sid found` regardless of the proxy fix — that is a separate web-adapter setting, not in scope of this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)