### PR TITLE
chore(deps): bump zustand to v5 (with migration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.aura",
-  "version": "0.9.299",
+  "version": "0.10.2-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.aura",
-      "version": "0.9.299",
+      "version": "0.10.2-next.1",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.3.2",
@@ -46,7 +46,7 @@
         "typescript": "^6.0.3",
         "vite": "^5.3.4",
         "vitepress": "^1.6.4",
-        "zustand": "^4.5.4"
+        "zustand": "^5.0.14"
       },
       "engines": {
         "node": ">=22"
@@ -12760,21 +12760,19 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -12784,6 +12782,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "typescript": "^6.0.3",
     "vite": "^5.3.4",
     "vitepress": "^1.6.4",
-    "zustand": "^4.5.4"
+    "zustand": "^5.0.14"
   }
 }

--- a/src-vis/pages/admin/AdminEditor.tsx
+++ b/src-vis/pages/admin/AdminEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect, memo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import { shallow } from 'zustand/shallow';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
 import {
     Plus,
     Trash2,
@@ -1156,7 +1157,8 @@ const TabBar = memo(function TabBar() {
     const activeTabId = useDashboardStore(
         (s) => (s.layouts.find((l) => l.id === s.activeLayoutId) ?? s.layouts[0]).activeTabId,
     );
-    const { addTab, setActiveTab, renameTab, removeTab, setTabSlug, updateTab, reorderTabs } = useDashboardStore(
+    const { addTab, setActiveTab, renameTab, removeTab, setTabSlug, updateTab, reorderTabs } = useStoreWithEqualityFn(
+        useDashboardStore,
         (s) => ({
             addTab: s.addTab,
             setActiveTab: s.setActiveTab,
@@ -1631,7 +1633,8 @@ export function AdminEditor() {
     // Narrow subscriptions — none of these change on tab switch, so AdminEditor
     // itself does NOT re-render when the user clicks a different tab.
     const activeLayoutId = useDashboardStore((s) => s.activeLayoutId);
-    const layoutOptions = useDashboardStore(
+    const layoutOptions = useStoreWithEqualityFn(
+        useDashboardStore,
         (s) => s.layouts.map((l) => ({ id: l.id, name: l.name })),
         (a, b) => a.length === b.length && a.every((l, i) => l.id === b[i].id && l.name === b[i].name),
     );


### PR DESCRIPTION
Supersedes #333 (Dependabot's plain bump, which breaks the build).

## Why #333 alone fails
zustand v5 removed the two-argument `useStore(selector, equalityFn)` form. The plain version bump breaks `tsc` with 15 type errors in `src-vis/pages/admin/AdminEditor.tsx` (verified locally). Neither the `check-and-lint` nor `adapter-tests` CI jobs run `npm run build`, so a plain merge would only surface the breakage at deploy time.

## What this PR does
- Bumps `zustand` 4.5.x → 5.0.14
- Migrates the two affected call sites in `AdminEditor.tsx` to `useStoreWithEqualityFn` from `zustand/traditional`, preserving exact render semantics:
  - `shallow` comparator for the actions selector
  - the custom id/name comparator for `layoutOptions`

All other stores already use the v5-compatible named `create` import; `WidgetFrame.tsx` already used `useStoreWithEqualityFn`.

## Verification
- `tsc` — clean
- `vite build` — clean (26s)
- `eslint AdminEditor.tsx` — clean

After merging this, close #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)