### PR TITLE
fix(socket): connect websocket-first so "Force web sockets" works

### DIFF
--- a/src-vis/hooks/useIoBroker.ts
+++ b/src-vis/hooks/useIoBroker.ts
@@ -152,7 +152,14 @@ function createSocket(url: string): IoBrokerSocket {
         return makeStubSocket();
     }
     ioLoadWarned = false;
-    const s = io.connect(url);
+    // transports: websocket first, polling as fallback. The classic socket.io
+    // client defaults to polling-first, which fails when the web adapter has
+    // "Force web sockets" enabled (server rejects the polling handshake) — so we
+    // must offer websocket first. @iobroker/ws ("pure web sockets") ignores this
+    // option and uses its own pure-WS connect. We deliberately do NOT pass
+    // `path` (socket.io's default /socket.io is already correct, and @iobroker/ws
+    // would mishandle it — it connects at the root).
+    const s = io.connect(url, { transports: ['websocket', 'polling'] });
 
     // A re-established connection is signalled differently depending on the
     // runtime socket library: the bundled classic socket.io-client re-fires


### PR DESCRIPTION
## Problem

With the web adapter's **"Force web sockets"** option enabled (but *not* "Use pure web sockets (iobroker.ws)"), aura could not connect.

"Force web sockets" keeps the classic socket.io server but allows **only** the WebSocket transport — the server rejects the polling handshake. #357 changed the connect to `io.connect(url)` with no options, so the classic socket.io v2 client falls back to its **polling-first** default → handshake refused → no connection.

## Fix

Restore `transports: ['websocket', 'polling']` (websocket-first, polling fallback). This was aura's behaviour before #218.

- **Classic socket.io**: connects via WebSocket directly → works with *and* without "Force web sockets"; polling stays as a fallback for restrictive proxies.
- **Pure web sockets (`@iobroker/ws`)**: ignores `transports` and uses its own pure-WS connect — unaffected.
- We still do **not** pass `path` (socket.io's `/socket.io` default is correct, and `@iobroker/ws` connects at the root).

## Verification (live, read-only via `?shot=1`)

Against a classic socket.io v2 instance:
- ✅ connected
- ✅ WebSocket opened at `…/socket.io/?EIO=3&transport=websocket`
- ✅ **0** polling XHR requests (pure websocket-first — exactly what "Force web sockets" needs)

tsc + eslint clean. `www/` not rebuilt (release step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
