### PR TITLE
fix(deps): pin zustand to v4 — v5 causes prod-only React #185 loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.aura",
-  "version": "0.10.2-next.1",
+  "version": "0.10.2-next.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.aura",
-      "version": "0.10.2-next.1",
+      "version": "0.10.2-next.2",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.3.2",
@@ -46,7 +46,7 @@
         "typescript": "^6.0.3",
         "vite": "^5.3.4",
         "vitepress": "^1.6.4",
-        "zustand": "^5.0.14"
+        "zustand": "^4.5.7"
       },
       "engines": {
         "node": ">=22"
@@ -12760,19 +12760,21 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12.7.0"
       },
       "peerDependencies": {
-        "@types/react": ">=18.0.0",
+        "@types/react": ">=16.8",
         "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
+        "react": ">=16.8"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -12782,9 +12784,6 @@
           "optional": true
         },
         "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "typescript": "^6.0.3",
     "vite": "^5.3.4",
     "vitepress": "^1.6.4",
-    "zustand": "^5.0.14"
+    "zustand": "^4.5.7"
   }
 }


### PR DESCRIPTION
## Problem

`aura.dering-online.de` crashes **immediately on load** with React error #185 ("Maximum update depth exceeded"), white-screening the dashboard. Shipped in `0.10.2-next.2`.

Root cause: **zustand v5** (bumped in #358). Its production bundle triggers an infinite render loop.

## Diagnosis (reproduced live against a real instance)

| Build | zustand | Result |
|---|---|---|
| Dev | v5 | Full dashboard (111 widgets), **0 errors** |
| Production | v4 | Full dashboard, **0 errors** |
| Production | v5 | **React #185** on every route (incl. minimal `/admin/login`) |

- The loop is **effect-driven** — no React error boundary catches it (React Router logs it), so it's not a render-phase selector instability (dev would otherwise throw React's "getSnapshot should be cached").
- It's **production-only** + **all routes**, i.e. a zustand-v5 runtime behaviour change, not a single bad component.
- A local `npm run build` silently bundles whichever zustand is in `node_modules`; the deployed bundle (`react-dom-DZ5PLAPP.js`) was a v5 build, which is why a v4 dev box doesn't show it.

## Fix

Pin `zustand` to `^4.5.7`. v4.5.x already exports `useStoreWithEqualityFn` (`zustand/traditional`) and `zustand/shallow`, so the equality-fn hooks migrated in #358 keep working unchanged. Verified: production build renders the real instance dashboard with **0 #185 hits** on `/` and `/admin/login`.

## Follow-up

The v5 incompatibility is real but elusive (prod-only, effect-driven). Re-attempting the v5 upgrade should be done with React DevTools Profiler against the live loop to identify the looping effect — not from static review or headless runs, which don't surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
