### PR TITLE
fix(proxy): guarantee a sid on pure-ws root upgrades (fixes 5s No-sid loop)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1091,10 +1091,24 @@ class Aura extends utils.Adapter {
             const isPureWs = parsedUrl.pathname === '/';
             if (isClassicSocketIo || isPureWs) {
                 const wsScheme = socketSecure ? 'wss' : 'ws';
+                let targetReqUrl = req.url;
+                // Pure web sockets (@iobroker/ws): the server (ioBroker.ws.server)
+                // closes any root WS upgrade that arrives without a `sid` query param
+                // ("No sid found" → 501 invalid sid → close after 500ms → the client
+                // reconnects every ~5s). The client always sends ?sid=<Date.now()>,
+                // but a reverse proxy in front of aura can drop the query on the root
+                // path. Guarantee a sid so the connection is accepted; the server only
+                // requires it to be non-empty (auth setups use the session cookie
+                // regardless). Classic socket.io is untouched — its sid is issued by
+                // the engine.io handshake under /socket.io/.
+                if (isPureWs && !parsedUrl.searchParams.has('sid')) {
+                    const sid = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+                    targetReqUrl = `${req.url}${parsedUrl.search ? '&' : '?'}sid=${sid}`;
+                }
                 proxyWebSocket(
                     req,
                     socket,
-                    `${wsScheme}://${socketHostPort}${req.url}`,
+                    `${wsScheme}://${socketHostPort}${targetReqUrl}`,
                     this.log,
                     socketSendForwardedFor,
                 );


### PR DESCRIPTION
## Symptom

With **"Use pure web sockets" (`@iobroker/ws`)** behind a reverse proxy, `web.X` logged `Error: "error" - No sid found from <ip>` every ~5 seconds and the dashboard silently reconnected on a loop. Classic socket.io / `forceWebSockets` were fine.

## Root cause (confirmed against the live server)

`ioBroker.ws.server`'s connection handler accepts a root WS upgrade only `if (query && query.sid)`. Without a `sid` it replies `[501,'error',['invalid sid']]` and **closes after 500 ms** → the client reconnects → repeat ≈ every 5 s.

The `@iobroker/ws` client always connects with `?sid=${Date.now()}` (never empty), and aura forwards `req.url` unchanged (verified). So the `sid` is dropped **above aura** — a reverse proxy in front of aura strips the query on the **root** path. Classic socket.io is unaffected because its `sid` is issued by the engine.io handshake under `/socket.io/`.

Direct test against the real backend:
```
wss://…/?sid=anything  -> OPEN, [0,1,"___ready___"], keepalive  -> stable
wss://…/               -> OPEN, [0,501,"error",["invalid sid"]], CLOSE @521ms
```

## Fix

On a **pure-ws root upgrade**, if no `sid` arrives, inject one before forwarding to the backend. The server accepts any non-empty `sid` for anonymous access (authenticated setups use the session cookie regardless), so aura becomes immune to query-stripping proxies. Mode-gated to the root path — classic / `forceWebSockets` upgrades are untouched.

`node --check` + eslint clean. Adapter-code only (`main.js`) — needs adapter rebuild/restart, no www rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
