### PR TITLE
chore(proxy): lower WS-upgrade diagnostic log to debug level

### DIFF
--- a/main.js
+++ b/main.js
@@ -1113,9 +1113,10 @@ class Aura extends utils.Adapter {
                     targetReqUrl = `${base}?sid=${sid}${extra ? `&${extra}` : ''}`;
                     injected = true;
                 }
-                // Diagnostic: shows what the backend actually receives. Remove once
-                // the pure-ws "No sid found" issue is confirmed resolved in the field.
-                this.log.info(
+                // Diagnostic (debug-level): shows what the backend actually receives
+                // for each WS upgrade — useful when chasing "No sid found" / protocol
+                // mismatches. Enable the adapter's debug log level to see it.
+                this.log.debug(
                     `aura: WS upgrade in="${req.url}" pure=${isPureWs} sid="${parsedUrl.searchParams.get('sid') ?? ''}" injected=${injected} -> "${targetReqUrl}"`,
                 );
                 proxyWebSocket(


### PR DESCRIPTION
Follow-up: the pure-ws 'No sid found' 5s loop was traced to stale classic-socket.io client tabs hitting a pure-ws backend (verified via the diagnostic log — aura always receives + forwards a valid sid; injected=false). Keep the per-upgrade diagnostic but at debug level so it no longer spams info. sid-injection safety net unchanged. node --check + eslint clean.