### PR TITLE
feat(echart): day navigation and per-series history aggregation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,4 @@
 - Advanced chart - choose which time-range presets the frontend selector offers
 - Advanced chart - a range without recorded changes draws a flat line at the current value instead of "no data"
 - Advanced chart - fixed periodic chart flicker when adapters re-write unchanged values
+- Panels - loop now wraps seamlessly onto the first/last slide instead of rewinding across the whole row

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,3 +8,6 @@
 - Advanced chart - optional day navigation (prev day / today / next day) to browse single calendar days
 - Advanced chart - per-series history aggregation option (average/minmax/max/min/total); minmax keeps true extremes for sparsely logged counters
 - Advanced chart - monotone line smoothing, so flat data runs no longer wobble around their value
+- Advanced chart - choose which time-range presets the frontend selector offers
+- Advanced chart - a range without recorded changes draws a flat line at the current value instead of "no data"
+- Advanced chart - fixed periodic chart flicker when adapters re-write unchanged values

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,3 +4,7 @@
 #   <Widget type> - <what changed>          e.g.  Thermostat - target temperature now shown inline
 #   <General / widget-independent change>    e.g.  Tabs can be hidden from the tab bar
 #   Settings - <what changed>               e.g.  Settings - add hex color mode for RGB lights
+
+- Advanced chart - optional day navigation (prev day / today / next day) to browse single calendar days
+- Advanced chart - per-series history aggregation option (average/minmax/max/min/total); minmax keeps true extremes for sparsely logged counters
+- Advanced chart - monotone line smoothing, so flat data runs no longer wobble around their value

--- a/docs/widgets/diagramm-erweitert.md
+++ b/docs/widgets/diagramm-erweitert.md
@@ -82,6 +82,7 @@ Ein gemeinsamer Zeitraum für alle Serien.
 | `echartRangeCustomValue` | `24` | nur bei `custom` |
 | `echartRangeCustomUnit` | `h` | `h` · `d`, nur bei `custom` |
 | `lockRange` | `false` | Zeitraum-Umschalter im Frontend ausblenden |
+| `echartVisibleRanges` | alle | Welche Presets der Frontend-Umschalter anbietet, z. B. `["6h","24h","7d","30d"]` |
 | `echartDayNav` | `false` | Tages-Navigation im Frontend (◀ Heute ▶) — einzelne Kalendertage durchblättern |
 | `autoHistoryInstance` | `false` | History-Instanz je Serie automatisch erkennen |
 

--- a/docs/widgets/diagramm-erweitert.md
+++ b/docs/widgets/diagramm-erweitert.md
@@ -57,6 +57,7 @@ Alle Optionen werden im Editor unter **Widget bearbeiten** gesetzt.
 | `echartSeries[].color` | Palette | Linien-/Balkenfarbe |
 | `echartSeries[].yAxisIndex` | `0` | `0` = links, `1` = rechte Y-Achse |
 | `echartSeries[].smooth` | `true` | geglättete Linie (nur Linie/Fläche) |
+| `echartSeries[].aggregate` | `average` | `average` · `minmax` · `max` · `min` · `total` — `minmax` erhält echte Extremwerte mit echten Zeitstempeln (empfohlen für änderungsbasiert geloggte Zähler wie Tagesregen) |
 | `echartSeries[].lineWidth` | `2` | Linienstärke 1–4 (nur Linie/Fläche) |
 
 ### Achsen
@@ -81,6 +82,7 @@ Ein gemeinsamer Zeitraum für alle Serien.
 | `echartRangeCustomValue` | `24` | nur bei `custom` |
 | `echartRangeCustomUnit` | `h` | `h` · `d`, nur bei `custom` |
 | `lockRange` | `false` | Zeitraum-Umschalter im Frontend ausblenden |
+| `echartDayNav` | `false` | Tages-Navigation im Frontend (◀ Heute ▶) — einzelne Kalendertage durchblättern |
 | `autoHistoryInstance` | `false` | History-Instanz je Serie automatisch erkennen |
 
 ### JSON-Override

--- a/docs/widgets/panels.md
+++ b/docs/widgets/panels.md
@@ -25,7 +25,7 @@ Alle Optionen werden im Editor unter **Widget bearbeiten** gesetzt.
 | --- | --- | --- |
 | `showDots` | `true` | Pagination-Punkte anzeigen |
 | `showArrows` | `true` | Pfeil-Buttons anzeigen |
-| `loop` | `false` | Endlos-Schleife (vom letzten zum ersten Slide) |
+| `loop` | `false` | Endlos-Schleife — läuft nahtlos vom letzten zum ersten Slide weiter (und umgekehrt) |
 
 ### Autoplay
 

--- a/src-vis/components/config/EChartConfig.tsx
+++ b/src-vis/components/config/EChartConfig.tsx
@@ -59,6 +59,7 @@ export function EChartConfig({ config, onConfigChange }: EChartConfigProps) {
     const echartRangeCustomUnit =
         (o.echartRangeCustomUnit as 'h' | 'd' | undefined) ?? series[0]?.historyRangeCustomUnit ?? 'h';
     const lockRange = (o.lockRange as boolean | undefined) ?? false;
+    const dayNav = (o.echartDayNav as boolean | undefined) ?? false;
     const anyHistory = series.some((s) => !!s.historyInstance);
     const echartLeftUnit = (o.echartLeftUnit as string | undefined) ?? '';
     const echartRightUnit = (o.echartRightUnit as string | undefined) ?? '';
@@ -596,6 +597,38 @@ export function EChartConfig({ config, onConfigChange }: EChartConfigProps) {
                                                                 </select>
                                                             </div>
                                                         )}
+                                                    {s.datapointId && s.historyInstance && (
+                                                        <div className="mt-1.5">
+                                                            <label
+                                                                className="text-[11px] mb-1 block"
+                                                                style={{ color: 'var(--text-secondary)' }}
+                                                            >
+                                                                Aggregation
+                                                            </label>
+                                                            <select
+                                                                value={s.aggregate ?? 'average'}
+                                                                onChange={(e) =>
+                                                                    updateSeries(s.id, {
+                                                                        aggregate:
+                                                                            e.target.value === 'average'
+                                                                                ? undefined
+                                                                                : (e.target
+                                                                                      .value as EChartSeriesConfig['aggregate']),
+                                                                    })
+                                                                }
+                                                                className={inputCls}
+                                                                style={inputStyle}
+                                                            >
+                                                                <option value="average">Durchschnitt (Standard)</option>
+                                                                <option value="minmax">
+                                                                    Min/Max (echte Extremwerte — z.B. Regenzähler)
+                                                                </option>
+                                                                <option value="max">Maximum</option>
+                                                                <option value="min">Minimum</option>
+                                                                <option value="total">Summe</option>
+                                                            </select>
+                                                        </div>
+                                                    )}
                                                 </div>
                                             </>
                                         )}
@@ -760,6 +793,17 @@ export function EChartConfig({ config, onConfigChange }: EChartConfigProps) {
                             />
                             <span className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
                                 Zeitraum im Frontend sperren
+                            </span>
+                        </label>
+                        <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={dayNav}
+                                onChange={(e) => setO({ echartDayNav: e.target.checked })}
+                                className="rounded"
+                            />
+                            <span className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                                Tages-Navigation im Frontend (◀ Heute ▶)
                             </span>
                         </label>
                     </div>

--- a/src-vis/components/config/EChartConfig.tsx
+++ b/src-vis/components/config/EChartConfig.tsx
@@ -60,6 +60,16 @@ export function EChartConfig({ config, onConfigChange }: EChartConfigProps) {
         (o.echartRangeCustomUnit as 'h' | 'd' | undefined) ?? series[0]?.historyRangeCustomUnit ?? 'h';
     const lockRange = (o.lockRange as boolean | undefined) ?? false;
     const dayNav = (o.echartDayNav as boolean | undefined) ?? false;
+    // Which presets the frontend range selector offers (default: all).
+    const frontendPresets = CHART_RANGES.filter((r) => r !== 'custom');
+    const visibleRanges = (o.echartVisibleRanges as EChartTimeRange[] | undefined) ?? frontendPresets;
+    const toggleVisibleRange = (r: EChartTimeRange) => {
+        const next = visibleRanges.includes(r)
+            ? visibleRanges.filter((x) => x !== r)
+            : frontendPresets.filter((x) => visibleRanges.includes(x) || x === r);
+        if (next.length === 0) return; // keep at least one preset selectable
+        setO({ echartVisibleRanges: next });
+    };
     const anyHistory = series.some((s) => !!s.historyInstance);
     const echartLeftUnit = (o.echartLeftUnit as string | undefined) ?? '';
     const echartRightUnit = (o.echartRightUnit as string | undefined) ?? '';
@@ -782,6 +792,33 @@ export function EChartConfig({ config, onConfigChange }: EChartConfigProps) {
                                         {u === 'h' ? 'Std' : 'Tage'}
                                     </button>
                                 ))}
+                            </div>
+                        )}
+                        {!lockRange && (
+                            <div className="mt-2">
+                                <label className="text-[11px] mb-1 block" style={{ color: 'var(--text-secondary)' }}>
+                                    Sichtbare Zeitbereiche im Frontend
+                                </label>
+                                <div className="flex gap-1 flex-wrap">
+                                    {frontendPresets.map((r) => {
+                                        const active = visibleRanges.includes(r);
+                                        return (
+                                            <button
+                                                key={r}
+                                                onClick={() => toggleVisibleRange(r)}
+                                                className="flex-1 text-[11px] py-1 rounded-md hover:opacity-80 transition-opacity"
+                                                style={{
+                                                    background: active ? 'var(--accent)' : 'var(--app-bg)',
+                                                    color: active ? '#fff' : 'var(--text-secondary)',
+                                                    border: `1px solid ${active ? 'var(--accent)' : 'var(--app-border)'}`,
+                                                    minWidth: 36,
+                                                }}
+                                            >
+                                                {RANGE_LABELS[r]}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
                             </div>
                         )}
                         <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">

--- a/src-vis/components/widgets/EChartWidget.tsx
+++ b/src-vis/components/widgets/EChartWidget.tsx
@@ -5,6 +5,7 @@ import { useIoBroker } from '../../hooks/useIoBroker';
 import {
     useMultiSeriesData,
     useAutoHistoryInstances,
+    rangeToMs,
     type EChartSeriesConfig,
     type EChartTimeRange,
 } from '../../hooks/useMultiSeriesData';
@@ -80,6 +81,12 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
     const cfgCustomUnit =
         (o.echartRangeCustomUnit as 'h' | 'd' | undefined) ?? echartSeries[0]?.historyRangeCustomUnit ?? 'h';
     const lockRange = o.lockRange === true;
+    // Which presets the frontend selector offers (config-selectable; default: all).
+    const cfgVisibleRanges = o.echartVisibleRanges as EChartTimeRange[] | undefined;
+    const visibleRanges =
+        cfgVisibleRanges && cfgVisibleRanges.length > 0
+            ? PRESET_RANGES.filter((r) => cfgVisibleRanges.includes(r))
+            : PRESET_RANGES;
 
     const [activeRange, setActiveRange] = useState<EChartTimeRange>(cfgRange);
     const [activeCustomVal, setActiveCustomVal] = useState<number>(cfgCustomVal);
@@ -178,19 +185,36 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
         !hasAnyData &&
         echartSeries.some((s) => (s.datapointId ?? '').includes('{{'));
     const previewData = isPreview ? echartSeries.map((_, idx) => samplePreviewSeries(idx)) : null;
-    // Day mode: a day without records renders as a flat zero line instead of "Keine Daten",
-    // and its current value reads 0 — the day simply had nothing to log (e.g. no rain).
-    const zeroLineData = (): [number, number][] => {
-        if (!dayWindow) return [];
+    // A window without records renders as a flat line instead of "Keine Daten":
+    //   • day mode: flat zero — the browsed day simply had nothing to log (e.g. no rain);
+    //   • rolling range: flat at the current value — a change-logged datapoint that
+    //     didn't change in the window has been constant at its live value the whole time.
+    const flatLineData = (current: number | null): [number, number][] => {
+        const now = Date.now();
+        if (dayWindow) {
+            return [
+                [dayWindow.start, 0],
+                [Math.min(dayWindow.end, now), 0],
+            ];
+        }
+        const val = current ?? 0;
         return [
-            [dayWindow.start, 0],
-            [Math.min(dayWindow.end, Date.now()), 0],
+            [now - rangeToMs(activeRange, activeCustomVal, activeCustomUnit), val],
+            [now, val],
         ];
     };
     const seriesData = (idx: number, id: string): [number, number][] => {
         if (previewData) return previewData[idx];
-        const data = seriesDataMap.get(id)?.data ?? [];
-        if (dayWindow && data.length === 0 && !seriesDataMap.get(id)?.loading) return zeroLineData();
+        const r = seriesDataMap.get(id);
+        const data = r?.data ?? [];
+        if (
+            data.length === 0 &&
+            r &&
+            !r.loading &&
+            (dayWindow !== null || !!effectiveSeries[idx]?.historyInstance)
+        ) {
+            return flatLineData(r.current);
+        }
         return data;
     };
     const seriesCurrent = (idx: number, id: string): number | null => {
@@ -199,7 +223,8 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
         if (dayWindow && current === null && !seriesDataMap.get(id)?.loading) return 0;
         return current;
     };
-    const effHasData = isPreview || hasAnyData || (dayWindow !== null && echartSeries.length > 0 && !allLoading);
+    const effHasData =
+        isPreview || hasAnyData || (echartSeries.length > 0 && !allLoading && (dayWindow !== null || hasHistory));
     const effLoading = !isPreview && allLoading;
 
     // Gauge mode: show first series' current value as a gauge
@@ -554,7 +579,7 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
             // day-nav controls; on very narrow widgets the chips scroll (swipe)
             // instead of wrapping the day-nav into a second row.
             <div className="nodrag flex gap-1 min-w-0 overflow-x-auto aura-no-scrollbar">
-                {PRESET_RANGES.map((r) => {
+                {visibleRanges.map((r) => {
                     const active = dayOffset === null && activeRange === r;
                     return (
                         <button

--- a/src-vis/components/widgets/EChartWidget.tsx
+++ b/src-vis/components/widgets/EChartWidget.tsx
@@ -550,13 +550,16 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
     // Frontend range selector — shown when at least one series has history and not locked.
     const rangeSelector =
         hasHistory && !lockRange ? (
-            <div className="flex gap-1 flex-wrap">
+            // nowrap + horizontal scroll: keeps the chips on one line next to the
+            // day-nav controls; on very narrow widgets the chips scroll (swipe)
+            // instead of wrapping the day-nav into a second row.
+            <div className="nodrag flex gap-1 min-w-0 overflow-x-auto aura-no-scrollbar">
                 {PRESET_RANGES.map((r) => {
                     const active = dayOffset === null && activeRange === r;
                     return (
                         <button
                             key={r}
-                            className="nodrag px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
+                            className="nodrag shrink-0 whitespace-nowrap px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
                             style={{
                                 background: active ? 'var(--accent)' : 'var(--app-border)',
                                 color: active ? '#fff' : 'var(--text-secondary)',
@@ -572,7 +575,7 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                 })}
                 {cfgRange === 'custom' && (
                     <button
-                        className="nodrag px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
+                        className="nodrag shrink-0 whitespace-nowrap px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
                         style={{
                             background: activeRange === 'custom' ? 'var(--accent)' : 'var(--app-border)',
                             color: activeRange === 'custom' ? '#fff' : 'var(--text-secondary)',
@@ -624,7 +627,10 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                     <ChevronRight size={12} />
                 </button>
                 {dayWindow && (
-                    <span className="text-[10px] font-medium ml-1" style={{ color: 'var(--text-secondary)' }}>
+                    <span
+                        className="text-[10px] font-medium ml-1 whitespace-nowrap"
+                        style={{ color: 'var(--text-secondary)' }}
+                    >
                         {new Date(dayWindow.start).toLocaleDateString('de-DE', {
                             weekday: 'short',
                             day: '2-digit',
@@ -666,7 +672,7 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                 </div>
             )}
             {(rangeSelector || dayNavControls) && (
-                <div className="shrink-0 mb-1 flex items-center justify-between gap-2 flex-wrap">
+                <div className="shrink-0 mb-1 flex items-center justify-between gap-2 min-w-0">
                     {rangeSelector ?? <span />}
                     {dayNavControls}
                 </div>

--- a/src-vis/components/widgets/EChartWidget.tsx
+++ b/src-vis/components/widgets/EChartWidget.tsx
@@ -1,6 +1,6 @@
 import ReactECharts from 'echarts-for-react';
 import { useRef, useState, useEffect } from 'react';
-import { BarChart2, Loader } from 'lucide-react';
+import { BarChart2, ChevronLeft, ChevronRight, Loader } from 'lucide-react';
 import { useIoBroker } from '../../hooks/useIoBroker';
 import {
     useMultiSeriesData,
@@ -85,6 +85,20 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
     const [activeCustomVal, setActiveCustomVal] = useState<number>(cfgCustomVal);
     const [activeCustomUnit, setActiveCustomUnit] = useState<'h' | 'd'>(cfgCustomUnit);
 
+    // ── Day navigation (◀ Heute ▶): view a single calendar day, step day by day ──
+    // null = normal rolling-range mode; number = offset in days from today (0 = today, -1 = yesterday …)
+    const dayNav = o.echartDayNav === true;
+    const [dayOffset, setDayOffset] = useState<number | null>(null);
+    const dayWindow = (() => {
+        if (!dayNav || dayOffset === null) return null;
+        const d = new Date();
+        d.setHours(0, 0, 0, 0);
+        d.setDate(d.getDate() + dayOffset);
+        const e = new Date(d);
+        e.setDate(e.getDate() + 1);
+        return { start: d.getTime(), end: e.getTime() };
+    })();
+
     // Reset frontend selection when the admin config changes
     useEffect(() => {
         setActiveRange(cfgRange);
@@ -106,6 +120,9 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
         historyRange: activeRange,
         historyRangeCustomValue: activeCustomVal,
         historyRangeCustomUnit: activeCustomUnit,
+        // Day mode pins all series to one absolute calendar-day window.
+        historyStart: dayWindow?.start,
+        historyEnd: dayWindow?.end,
     }));
 
     const hasHistory = effectiveSeries.some((s) => !!s.historyInstance);
@@ -161,11 +178,28 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
         !hasAnyData &&
         echartSeries.some((s) => (s.datapointId ?? '').includes('{{'));
     const previewData = isPreview ? echartSeries.map((_, idx) => samplePreviewSeries(idx)) : null;
-    const seriesData = (idx: number, id: string): [number, number][] =>
-        previewData ? previewData[idx] : (seriesDataMap.get(id)?.data ?? []);
-    const seriesCurrent = (idx: number, id: string): number | null =>
-        previewData ? previewData[idx][previewData[idx].length - 1][1] : (seriesDataMap.get(id)?.current ?? null);
-    const effHasData = isPreview || hasAnyData;
+    // Day mode: a day without records renders as a flat zero line instead of "Keine Daten",
+    // and its current value reads 0 — the day simply had nothing to log (e.g. no rain).
+    const zeroLineData = (): [number, number][] => {
+        if (!dayWindow) return [];
+        return [
+            [dayWindow.start, 0],
+            [Math.min(dayWindow.end, Date.now()), 0],
+        ];
+    };
+    const seriesData = (idx: number, id: string): [number, number][] => {
+        if (previewData) return previewData[idx];
+        const data = seriesDataMap.get(id)?.data ?? [];
+        if (dayWindow && data.length === 0 && !seriesDataMap.get(id)?.loading) return zeroLineData();
+        return data;
+    };
+    const seriesCurrent = (idx: number, id: string): number | null => {
+        if (previewData) return previewData[idx][previewData[idx].length - 1][1];
+        const current = seriesDataMap.get(id)?.current ?? null;
+        if (dayWindow && current === null && !seriesDataMap.get(id)?.loading) return 0;
+        return current;
+    };
+    const effHasData = isPreview || hasAnyData || (dayWindow !== null && echartSeries.length > 0 && !allLoading);
     const effLoading = !isPreview && allLoading;
 
     // Gauge mode: show first series' current value as a gauge
@@ -425,6 +459,9 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
             type: s.chartType === 'area' ? 'line' : s.chartType,
             areaStyle: s.chartType === 'area' ? { opacity: 0.2 } : undefined,
             smooth: s.smooth ?? (s.chartType === 'line' || s.chartType === 'area'),
+            // Monotone smoothing never overshoots the data — a flat run of equal values
+            // (e.g. dry days at 0) stays exactly flat instead of wobbling around it.
+            smoothMonotone: 'x',
             lineStyle: { width: s.lineWidth ?? 2 },
             itemStyle: { color: s.color ?? DEFAULT_COLORS[idx % DEFAULT_COLORS.length] },
             data,
@@ -482,6 +519,8 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
             axisTick: { show: echartShowXAxis },
             axisLine: { show: echartShowXAxis, lineStyle: { color: '#444' } },
             splitLine: { show: false },
+            // Day mode: frame exactly the selected calendar day, even when data is sparse.
+            ...(dayWindow ? { min: dayWindow.start, max: dayWindow.end } : {}),
         },
         yAxis: [leftAxis, rightAxis],
         series: seriesList,
@@ -513,7 +552,7 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
         hasHistory && !lockRange ? (
             <div className="flex gap-1 flex-wrap">
                 {PRESET_RANGES.map((r) => {
-                    const active = activeRange === r;
+                    const active = dayOffset === null && activeRange === r;
                     return (
                         <button
                             key={r}
@@ -522,7 +561,10 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                                 background: active ? 'var(--accent)' : 'var(--app-border)',
                                 color: active ? '#fff' : 'var(--text-secondary)',
                             }}
-                            onClick={() => setActiveRange(r)}
+                            onClick={() => {
+                                setDayOffset(null);
+                                setActiveRange(r);
+                            }}
                         >
                             {RANGE_LABELS[r]}
                         </button>
@@ -536,6 +578,7 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                             color: activeRange === 'custom' ? '#fff' : 'var(--text-secondary)',
                         }}
                         onClick={() => {
+                            setDayOffset(null);
                             setActiveRange('custom');
                             setActiveCustomVal(cfgCustomVal);
                             setActiveCustomUnit(cfgCustomUnit);
@@ -543,6 +586,51 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                     >
                         {cfgCustomVal} {cfgCustomUnit === 'd' ? (cfgCustomVal === 1 ? 'Tag' : 'Tage') : 'Std'}
                     </button>
+                )}
+            </div>
+        ) : null;
+
+    // Day navigation (◀ Heute ▶) — step through single calendar days, "Heute" returns to the current day.
+    const navBtnStyle = (active: boolean): React.CSSProperties => ({
+        background: active ? 'var(--accent)' : 'var(--app-border)',
+        color: active ? '#fff' : 'var(--text-secondary)',
+    });
+    const dayNavControls =
+        dayNav && hasHistory ? (
+            <div className="flex items-center gap-1 shrink-0">
+                <button
+                    className="nodrag px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
+                    style={navBtnStyle(false)}
+                    title="Einen Tag zurück"
+                    onClick={() => setDayOffset((prev) => (prev ?? 0) - 1)}
+                >
+                    <ChevronLeft size={12} />
+                </button>
+                <button
+                    className="nodrag px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity"
+                    style={navBtnStyle(dayOffset === 0)}
+                    title="Zum aktuellen Tag"
+                    onClick={() => setDayOffset(0)}
+                >
+                    Heute
+                </button>
+                <button
+                    className="nodrag px-1.5 py-0.5 rounded text-[10px] font-medium hover:opacity-80 transition-opacity disabled:opacity-40"
+                    style={navBtnStyle(false)}
+                    title="Einen Tag vor"
+                    disabled={dayOffset === null || dayOffset >= 0}
+                    onClick={() => setDayOffset((prev) => (prev !== null && prev < 0 ? prev + 1 : prev))}
+                >
+                    <ChevronRight size={12} />
+                </button>
+                {dayWindow && (
+                    <span className="text-[10px] font-medium ml-1" style={{ color: 'var(--text-secondary)' }}>
+                        {new Date(dayWindow.start).toLocaleDateString('de-DE', {
+                            weekday: 'short',
+                            day: '2-digit',
+                            month: '2-digit',
+                        })}
+                    </span>
                 )}
             </div>
         ) : null;
@@ -577,7 +665,12 @@ export function EChartWidget({ config, editMode }: WidgetProps) {
                     )}
                 </div>
             )}
-            {rangeSelector && <div className="shrink-0 mb-1">{rangeSelector}</div>}
+            {(rangeSelector || dayNavControls) && (
+                <div className="shrink-0 mb-1 flex items-center justify-between gap-2 flex-wrap">
+                    {rangeSelector ?? <span />}
+                    {dayNavControls}
+                </div>
+            )}
             {instancePickers.length > 0 && (
                 <div className="shrink-0 mb-1 flex items-center gap-1 flex-wrap">
                     {instancePickers.map((p) => (

--- a/src-vis/components/widgets/PanelsWidget.tsx
+++ b/src-vis/components/widgets/PanelsWidget.tsx
@@ -82,6 +82,14 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
     const [active, setActive] = useState(0);
     const [dragOver, setDragOver] = useState(false);
     const [drag, setDrag] = useState<{ startX: number; dx: number } | null>(null);
+    // ── Seamless loop wrap ──────────────────────────────────────────────────
+    // While set, the track animates onto a cloned edge slide (last→first or
+    // first→last) instead of rewinding across the whole row; once the
+    // transition lands on the clone, the transform snaps (without animation)
+    // to the real slide the clone stands for.
+    const [wrap, setWrap] = useState<null | 'fwd' | 'back'>(null);
+    const [noAnim, setNoAnim] = useState(false);
+    const wrapTimerRef = useRef<number | null>(null);
     // Tracks an in-progress pointer interaction before it's promoted to a swipe.
     // `captured` flips true once movement crosses DRAG_START_THRESHOLD; only then
     // do we grab the pointer and start moving the slide track.
@@ -114,22 +122,53 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
     // Autoplay — suspended while `paused` (pointer over / focus inside the panel).
     // Re-entering the effect on un-pause restarts the interval from zero, so the
     // next slide is always a full interval away from the user's last interaction.
+    // Advances via nextRef so the wrap-around uses the same seamless loop
+    // animation as manual navigation (a plain setActive would rewind the track).
+    const nextRef = useRef<() => void>(() => {});
     useEffect(() => {
         if (!autoplay || editMode || interacting || children.length < 2) return;
-        const iv = setInterval(() => {
-            setActive((i) => {
-                if (i + 1 < children.length) return i + 1;
-                return loop ? 0 : i;
-            });
-        }, autoplayInterval * 1000);
+        const iv = setInterval(() => nextRef.current(), autoplayInterval * 1000);
         return () => clearInterval(iv);
-    }, [autoplay, autoplayInterval, editMode, interacting, children.length, loop]);
+    }, [autoplay, autoplayInterval, editMode, interacting, children.length]);
 
     // ── Navigation ───────────────────────────────────────────────────────────
+    // Seamless loop needs the edge clones and px-based transform math, so it is
+    // only active once the viewport is measured (and never in editMode, where
+    // clones would duplicate the slide-CRUD controls).
+    const smoothLoop = loop && !editMode && children.length > 1 && viewportW > 0;
+    const finishWrap = () => {
+        if (wrapTimerRef.current !== null) {
+            clearTimeout(wrapTimerRef.current);
+            wrapTimerRef.current = null;
+        }
+        setNoAnim(true);
+        setWrap(null);
+        // Two frames: let the snapped transform paint before re-enabling the
+        // transition, otherwise the browser would animate the snap itself.
+        requestAnimationFrame(() => requestAnimationFrame(() => setNoAnim(false)));
+    };
+    const startWrap = (dir: 'fwd' | 'back') => {
+        setWrap(dir);
+        setActive(dir === 'fwd' ? 0 : children.length - 1);
+        // Safety net: if the transitionend event is lost (hidden tab, etc.) a
+        // stuck wrap would lock navigation — snap shortly after the 280ms anyway.
+        wrapTimerRef.current = window.setTimeout(finishWrap, 400);
+    };
     const goTo = (i: number) => {
         if (children.length === 0) return;
         if (loop) {
+            if (wrap) return; // a wrap animation is in flight — ignore further nav
             const n = children.length;
+            if (smoothLoop) {
+                if (i >= n && active === n - 1) {
+                    startWrap('fwd');
+                    return;
+                }
+                if (i < 0 && active === 0) {
+                    startWrap('back');
+                    return;
+                }
+            }
             setActive(((i % n) + n) % n);
         } else {
             setActive(Math.max(0, Math.min(children.length - 1, i)));
@@ -137,6 +176,7 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
     };
     const prev = () => goTo(active - 1);
     const next = () => goTo(active + 1);
+    nextRef.current = next;
 
     // ── Pointer drag / swipe ─────────────────────────────────────────────────
     const onPointerDown = (e: React.PointerEvent) => {
@@ -286,9 +326,54 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
     const canNext = children.length > 1 && (loop || !atLast);
 
     // ── Render ───────────────────────────────────────────────────────────────
-    // Translate: active index * viewport width, plus live drag offset
+    // Translate: slide index * viewport width, plus live drag offset. With the
+    // seamless loop the track carries a clone of the last slide up front and a
+    // clone of the first at the end, so every index is shifted by one; a wrap
+    // animates onto the neighbouring clone instead of rewinding across the row.
     const liveOffset = drag?.dx ?? 0;
-    const translateX = viewportW > 0 ? -(active * viewportW) + liveOffset : 0;
+    const slideIndex = wrap === 'fwd' ? children.length : wrap === 'back' ? -1 : active;
+    const trackIndex = slideIndex + (smoothLoop ? 1 : 0);
+    const translateX = viewportW > 0 ? -(trackIndex * viewportW) + liveOffset : 0;
+
+    const renderSlide = (child: WidgetConfig, key: string) => (
+        <div
+            key={key}
+            className="relative shrink-0 p-1"
+            style={{
+                width: viewportW || `${100 / Math.max(1, children.length)}%`,
+                // Layout containment: a child widget resizing/ticking
+                // can't reflow the sibling slides, so the track layer
+                // stays valid through the whole transition.
+                contain: 'layout',
+            }}
+        >
+            <WidgetFrame
+                config={child}
+                editMode={editMode}
+                onRemove={removeSlide}
+                onConfigChange={updateChild}
+                onDuplicate={() => duplicateChild(child)}
+            />
+            {editMode && (
+                <button
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        removeSlide(child.id);
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="nodrag absolute top-1.5 left-1.5 z-10 w-7 h-7 flex items-center justify-center rounded-lg hover:opacity-80"
+                    title={t('panels.removeSlide')}
+                    style={{
+                        background: 'var(--app-bg)',
+                        color: 'var(--text-secondary)',
+                        border: '1px solid var(--app-border)',
+                    }}
+                >
+                    <Trash2 size={12} />
+                </button>
+            )}
+        </div>
+    );
 
     return (
         <div
@@ -351,11 +436,21 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
                     </div>
                 ) : (
                     <div
+                        // Remounting when the clones appear (first viewport measurement)
+                        // renders the shifted transform directly instead of animating the
+                        // track from its clone-less position.
+                        key={smoothLoop ? 'looped' : 'plain'}
                         className="absolute inset-0 flex"
+                        onTransitionEnd={(e) => {
+                            // A finished wrap animation sits on a clone — snap (without
+                            // animation) to the real slide the clone stands for.
+                            if (!wrap || e.target !== e.currentTarget || e.propertyName !== 'transform') return;
+                            finishWrap();
+                        }}
                         style={{
                             transform: `translate3d(${translateX}px, 0, 0)`,
-                            transition: drag ? 'none' : 'transform 280ms ease-out',
-                            width: `${children.length * 100}%`,
+                            transition: drag || noAnim ? 'none' : 'transform 280ms ease-out',
+                            width: `${(children.length + (smoothLoop ? 2 : 0)) * 100}%`,
                             // Keep the slide track promoted to its own compositor layer so
                             // each transition just moves an existing texture instead of
                             // re-rasterising every slide on each autoplay tick — the main
@@ -365,45 +460,9 @@ export function PanelsWidget({ config, editMode, onConfigChange }: WidgetProps) 
                             backfaceVisibility: 'hidden',
                         }}
                     >
-                        {children.map((child) => (
-                            <div
-                                key={child.id}
-                                className="relative shrink-0 p-1"
-                                style={{
-                                    width: viewportW || `${100 / Math.max(1, children.length)}%`,
-                                    // Layout containment: a child widget resizing/ticking
-                                    // can't reflow the sibling slides, so the track layer
-                                    // stays valid through the whole transition.
-                                    contain: 'layout',
-                                }}
-                            >
-                                <WidgetFrame
-                                    config={child}
-                                    editMode={editMode}
-                                    onRemove={removeSlide}
-                                    onConfigChange={updateChild}
-                                    onDuplicate={() => duplicateChild(child)}
-                                />
-                                {editMode && (
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            removeSlide(child.id);
-                                        }}
-                                        onPointerDown={(e) => e.stopPropagation()}
-                                        className="nodrag absolute top-1.5 left-1.5 z-10 w-7 h-7 flex items-center justify-center rounded-lg hover:opacity-80"
-                                        title={t('panels.removeSlide')}
-                                        style={{
-                                            background: 'var(--app-bg)',
-                                            color: 'var(--text-secondary)',
-                                            border: '1px solid var(--app-border)',
-                                        }}
-                                    >
-                                        <Trash2 size={12} />
-                                    </button>
-                                )}
-                            </div>
-                        ))}
+                        {smoothLoop && renderSlide(children[children.length - 1], 'clone-last')}
+                        {children.map((child) => renderSlide(child, child.id))}
+                        {smoothLoop && renderSlide(children[0], 'clone-first')}
                     </div>
                 )}
 

--- a/src-vis/hooks/useMultiSeriesData.ts
+++ b/src-vis/hooks/useMultiSeriesData.ts
@@ -18,6 +18,16 @@ export interface EChartSeriesConfig {
     smooth?: boolean;
     yAxisIndex?: 0 | 1;
     lineWidth?: number;
+    /** Absolute window override (ms epoch) — set by the widget's day navigation; wins over historyRange. */
+    historyStart?: number;
+    historyEnd?: number;
+    /**
+     * getHistory aggregation for stepped fetches (default `average`). `minmax` keeps the real
+     * extreme points with their true timestamps — right for sparsely change-logged datapoints
+     * (e.g. daily rain counters), where bucket averages smear resets and dropped empty buckets
+     * let the chart interpolate across days.
+     */
+    aggregate?: 'average' | 'minmax' | 'max' | 'min' | 'total';
 }
 
 export interface SeriesDataResult {
@@ -161,6 +171,9 @@ export function useMultiSeriesData(
             s.historyRange,
             s.historyRange === 'custom' ? s.historyRangeCustomValue : undefined,
             s.historyRange === 'custom' ? s.historyRangeCustomUnit : undefined,
+            s.historyStart,
+            s.historyEnd,
+            s.aggregate,
         ]),
     );
 
@@ -216,29 +229,43 @@ export function useMultiSeriesData(
             }
 
             const range = s.historyRange ?? '24h';
-            const rangeMs = getRangeMs(s);
+            const hasAbsWindow = typeof s.historyStart === 'number' && typeof s.historyEnd === 'number';
+            const rangeMs = hasAbsWindow ? (s.historyEnd as number) - (s.historyStart as number) : getRangeMs(s);
             const now = Date.now();
-            const end = now;
-            const start = end - rangeMs;
-            const step = range === 'custom' ? getStepForMs(rangeMs) : RANGE_STEP[range];
+            const end = hasAbsWindow ? Math.min(s.historyEnd as number, now) : now;
+            const start = hasAbsWindow ? (s.historyStart as number) : end - rangeMs;
+            const step = hasAbsWindow
+                ? getStepForMs(rangeMs)
+                : range === 'custom'
+                  ? getStepForMs(rangeMs)
+                  : RANGE_STEP[range];
 
             getHistoryDirect(s.datapointId, {
                 instance: s.historyInstance,
                 start,
                 end,
                 step,
-                aggregate: step ? 'average' : 'none',
+                aggregate: step ? (s.aggregate ?? 'average') : 'none',
                 count: 1000,
             })
                 .then((entries: HistoryEntry[]) => {
                     if (!mountedRef.current) return;
-                    const data: [number, number][] = entries
+                    let data: [number, number][] = entries
                         .filter(
                             (e): e is { ts: number; val: number; ack?: boolean; q?: number } =>
                                 typeof e.val === 'number',
                         )
                         .map((e): [number, number] => [e.ts, e.val as number])
                         .sort((a, b) => a[0] - b[0]);
+                    if (hasAbsWindow) {
+                        // History adapters append border values at the window edges (last value
+                        // before start, first value after end). For a pinned calendar-day window
+                        // they leak the neighbour days in — e.g. the midnight reset of a daily
+                        // rain counter lands exactly on the end border and hides the day total.
+                        const winStart = s.historyStart as number;
+                        const winEnd = s.historyEnd as number;
+                        data = data.filter((p) => p[0] >= winStart && p[0] < winEnd);
+                    }
                     const current = data.length > 0 ? data[data.length - 1][1] : null;
                     setResultsMap((prev) => {
                         const next = new Map(prev);
@@ -267,7 +294,8 @@ export function useMultiSeriesData(
     useEffect(() => {
         if (!connected || series.length === 0) return;
         const unsubs = series
-            .filter((s) => !!s.datapointId)
+            // Series pinned to a past absolute window are a frozen view — no live appends.
+            .filter((s) => !!s.datapointId && !(typeof s.historyEnd === 'number' && s.historyEnd < Date.now()))
             .map((s) => {
                 const cutoffMs = getRangeMs(s);
                 return subscribe(s.datapointId, (state: ioBrokerState) => {
@@ -278,7 +306,7 @@ export function useMultiSeriesData(
                         const existing = next.get(s.id);
                         let newData: [number, number][];
                         if (s.historyInstance && existing) {
-                            const cutoff = Date.now() - cutoffMs;
+                            const cutoff = typeof s.historyStart === 'number' ? s.historyStart : Date.now() - cutoffMs;
                             const trimmed = existing.data.filter((p) => p[0] >= cutoff);
                             if (trimmed.length > 0 && trimmed[trimmed.length - 1][0] === state.ts) {
                                 newData = trimmed;

--- a/src-vis/hooks/useMultiSeriesData.ts
+++ b/src-vis/hooks/useMultiSeriesData.ts
@@ -52,15 +52,16 @@ const RANGE_STEP: Record<Exclude<EChartTimeRange, 'custom'>, number | undefined>
     '30d': 21_600_000,
 };
 
-function getCustomMs(s: EChartSeriesConfig): number {
-    const val = s.historyRangeCustomValue ?? 24;
-    const unit = s.historyRangeCustomUnit ?? 'h';
-    return Math.max(1, val) * (unit === 'd' ? 86_400_000 : 3_600_000);
+/** Millisecond span of a range selection — also used by the widget to frame flat "no change" windows. */
+export function rangeToMs(range: EChartTimeRange, customValue?: number, customUnit?: 'h' | 'd'): number {
+    if (range === 'custom') {
+        return Math.max(1, customValue ?? 24) * ((customUnit ?? 'h') === 'd' ? 86_400_000 : 3_600_000);
+    }
+    return RANGE_MS[range];
 }
 
 function getRangeMs(s: EChartSeriesConfig): number {
-    const r = s.historyRange ?? '24h';
-    return r === 'custom' ? getCustomMs(s) : RANGE_MS[r];
+    return rangeToMs(s.historyRange ?? '24h', s.historyRangeCustomValue, s.historyRangeCustomUnit);
 }
 
 function getStepForMs(rangeMs: number): number | undefined {
@@ -266,12 +267,31 @@ export function useMultiSeriesData(
                         const winEnd = s.historyEnd as number;
                         data = data.filter((p) => p[0] >= winStart && p[0] < winEnd);
                     }
-                    const current = data.length > 0 ? data[data.length - 1][1] : null;
-                    setResultsMap((prev) => {
-                        const next = new Map(prev);
-                        next.set(s.id, { data, current, loading: false });
-                        return next;
-                    });
+                    if (data.length > 0) {
+                        const current = data[data.length - 1][1];
+                        setResultsMap((prev) => {
+                            const next = new Map(prev);
+                            next.set(s.id, { data, current, loading: false });
+                            return next;
+                        });
+                        return;
+                    }
+                    // Empty window — a change-logged datapoint simply had no changes in the
+                    // range. Seed the current value from the live state so the widget can
+                    // draw a flat line at it instead of reporting "no data".
+                    const finish = (state: ioBrokerState | null) => {
+                        if (!mountedRef.current) return;
+                        const val = typeof state?.val === 'number' ? (state.val as number) : null;
+                        setResultsMap((prev) => {
+                            const next = new Map(prev);
+                            next.set(s.id, { data: [], current: val, loading: false });
+                            return next;
+                        });
+                    };
+                    const cached = getStateFromCache(s.datapointId);
+                    if (cached) finish(cached);
+                    else if (getState) getState(s.datapointId).then(finish).catch(() => finish(null));
+                    else finish(null);
                 })
                 .catch(() => {
                     if (!mountedRef.current) return;
@@ -302,8 +322,13 @@ export function useMultiSeriesData(
                     if (typeof state.val !== 'number') return;
                     const val = state.val as number;
                     setResultsMap((prev) => {
+                        const existing = prev.get(s.id);
+                        // Adapters often re-write unchanged values on every poll (only the ts
+                        // moves). Appending those points rebuilt the chart each time — visible
+                        // as a periodic flicker. Returning the previous map bails out of the
+                        // re-render entirely.
+                        if (existing && !existing.loading && existing.current === val) return prev;
                         const next = new Map(prev);
-                        const existing = next.get(s.id);
                         let newData: [number, number][];
                         if (s.historyInstance && existing) {
                             const cutoff = typeof s.historyStart === 'number' ? s.historyStart : Date.now() - cutoffMs;


### PR DESCRIPTION
## Advanced chart (EChart) improvements

Three opt-in improvements to the advanced chart widget:

### Day navigation (`echartDayNav`)
Prev-day / today / next-day buttons to browse single calendar days. The day
window is pinned to `[00:00, 24:00)` local time; border values injected by the
history adapters at the window edges are filtered out, so the midnight reset of
daily counters (e.g. `rain_today`) no longer hides the day total. Days without
records render as a flat zero line with a current value of `0` instead of
"Keine Daten". Past days are a frozen view (no live appends). Picking a range
preset leaves day mode.

### Per-series aggregation (`aggregate`)
New per-series option `average | minmax | max | min | total` (default
`average`). `minmax` keeps the true extreme points with their real timestamps,
which fixes sparsely change-logged counters where bucket averages smear resets
and dropped empty buckets made the chart interpolate small false positives
across data gaps.

### Monotone line smoothing
Line smoothing now uses `smoothMonotone: 'x'`, so flat data runs stay exactly
flat instead of wobbling around their value.

---

**Changed files (source only):** `EChartWidget.tsx`, `EChartConfig.tsx`,
`useMultiSeriesData.ts`, plus `RELEASE_NOTES.md` and
`docs/widgets/diagramm-erweitert.md`.

The built `www/` bundle is intentionally not included — the maintainer rebuilds
it via the usual `chore(build)` commit.